### PR TITLE
Setter in der LibClient

### DIFF
--- a/src/LibClient.cpp
+++ b/src/LibClient.cpp
@@ -154,18 +154,18 @@ namespace libclient {
                                                                network(std::move(callback), model) {}
 
     bool LibClient::setName(const std::string &name) {
-        if(model->clientState.name.empty()){
-            model->clientState.name = name;
-            return true;
+        if(network.getState() != Network::NetworkState::NOT_CONNECTED && network.getState() != Network::NetworkState::CONNECTED){
+            return false;
         }
-        return false;
+        model->clientState.name = name;
+        return true;
     }
 
     bool LibClient::setRole(const spy::network::RoleEnum &role) {
-        if(model->clientState.role == spy::network::RoleEnum::INVALID){
-            model->clientState.role = role;
-            return true;
+        if(network.getState() != Network::NetworkState::NOT_CONNECTED && network.getState() != Network::NetworkState::CONNECTED){
+            return false;
         }
-        return false;
+        model->clientState.role = role;
+        return true;
     }
 }

--- a/src/LibClient.cpp
+++ b/src/LibClient.cpp
@@ -6,6 +6,8 @@
  */
 #include "LibClient.hpp"
 
+#include <utility>
+
 namespace libclient {
 
     const spy::util::UUID &LibClient::getId() const {
@@ -137,5 +139,13 @@ namespace libclient {
     }
 
     LibClient::LibClient(std::shared_ptr<Callback> callback) : model(std::make_shared<Model>()),
-                                                               network(callback, model) {}
+                                                               network(std::move(callback), model) {}
+
+    void LibClient::setName(const std::string &name) {
+        model->clientState.name = name;
+    }
+
+    void LibClient::setRole(const spy::network::RoleEnum &role) {
+        model->clientState.role = role;
+    }
 }

--- a/src/LibClient.cpp
+++ b/src/LibClient.cpp
@@ -141,11 +141,19 @@ namespace libclient {
     LibClient::LibClient(std::shared_ptr<Callback> callback) : model(std::make_shared<Model>()),
                                                                network(std::move(callback), model) {}
 
-    void LibClient::setName(const std::string &name) {
-        model->clientState.name = name;
+    bool LibClient::setName(const std::string &name) {
+        if(model->clientState.name.empty()){
+            model->clientState.name = name;
+            return true;
+        }
+        return false;
     }
 
-    void LibClient::setRole(const spy::network::RoleEnum &role) {
-        model->clientState.role = role;
+    bool LibClient::setRole(const spy::network::RoleEnum &role) {
+        if(model->clientState.role == spy::network::RoleEnum::INVALID){
+            model->clientState.role = role;
+            return true;
+        }
+        return false;
     }
 }

--- a/src/LibClient.hpp
+++ b/src/LibClient.hpp
@@ -84,6 +84,10 @@ namespace libclient {
             [[nodiscard]] const std::optional<spy::statistics::VictoryEnum> &getWinningReason() const;
 
             [[nodiscard]] bool hasReplay() const;
+
+            void setName(const std::string &name);
+
+            void setRole(const spy::network::RoleEnum &role);
     };
 
 }

--- a/src/LibClient.hpp
+++ b/src/LibClient.hpp
@@ -85,9 +85,9 @@ namespace libclient {
 
             [[nodiscard]] bool hasReplay() const;
 
-            void setName(const std::string &name);
+            bool setName(const std::string &name);
 
-            void setRole(const spy::network::RoleEnum &role);
+            bool setRole(const spy::network::RoleEnum &role);
     };
 
 }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1,5 +1,3 @@
-#include <utility>
-
 /**
  * @file   Network.cpp
  * @author Carolin
@@ -36,7 +34,7 @@ namespace libclient {
     Network::Network(std::shared_ptr<Callback> c, std::shared_ptr<Model> m) : callback(std::move(c)),
                                                                               model(std::move(m)) {}
 
-    void Network::onReceiveMessage(std::string message) {
+    void Network::onReceiveMessage(const std::string& message) {
         auto json = nlohmann::json::parse(message);
         auto mc = json.get<spy::network::MessageContainer>();
 
@@ -203,6 +201,7 @@ namespace libclient {
 
     void Network::onClose() {
         state = model->clientState.id.has_value() ? NetworkState::WELCOMED : NetworkState::CONNECTED;
+        state = model->clientState.role == spy::network::RoleEnum::SPECTATOR ? NetworkState::CONNECTED : state;
         callback->connectionLost();
     }
 
@@ -214,13 +213,14 @@ namespace libclient {
         model = std::make_shared<Model>();
     }
 
-    bool Network::sendHello(std::string name, spy::network::RoleEnum role) {
-        auto message = spy::network::messages::Hello(model->clientState.id.value(), std::move(name), role);
+    bool Network::sendHello(const std::string& name, spy::network::RoleEnum role) {
+        auto message = spy::network::messages::Hello(model->clientState.id.value(), name, role);
         if (!message.validate() || state != NetworkState::CONNECTED) {
             return false;
         }
         model->clientState.role = role;
         model->clientState.name = name;
+        state = NetworkState::SENT_HELLO;
         nlohmann::json j = message;
         webSocketClient->send(j.dump());
         return true;
@@ -263,7 +263,7 @@ namespace libclient {
 
     bool Network::sendGameLeave() {
         auto message = spy::network::messages::GameLeave(model->clientState.id.value());
-        if (!message.validate(model->clientState.role) || state == NetworkState::NOT_CONNECTED || state == NetworkState::CONNECTED) {
+        if (!message.validate(model->clientState.role) || state == NetworkState::NOT_CONNECTED || state == NetworkState::CONNECTED || state == Network::SENT_HELLO) {
             return false;
         }
         nlohmann::json j = message;
@@ -309,5 +309,9 @@ namespace libclient {
         nlohmann::json j = message;
         webSocketClient->send(j.dump());
         return true;
+    }
+
+    Network::NetworkState Network::getState() const {
+        return state;
     }
 }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -200,8 +200,13 @@ namespace libclient {
     }
 
     void Network::onClose() {
-        state = model->clientState.id.has_value() ? NetworkState::WELCOMED : NetworkState::CONNECTED;
-        state = model->clientState.role == spy::network::RoleEnum::SPECTATOR ? NetworkState::CONNECTED : state;
+        if ( model->clientState.role == spy::network::RoleEnum::SPECTATOR) {
+            // spectators are not remembered by server when connection is lost
+            state = NetworkState::CONNECTED;
+        } else {
+            // if server already knows client WELCOMED (-> reconnect possible), else CONNECTED
+            state = model->clientState.id.has_value() ? NetworkState::WELCOMED : NetworkState::CONNECTED;
+        }
         callback->connectionLost();
     }
 

--- a/src/Network.hpp
+++ b/src/Network.hpp
@@ -23,10 +23,11 @@
 namespace libclient {
 
     class Network {
-        private:
+        public:
             enum NetworkState {
                 NOT_CONNECTED,
                 CONNECTED,
+                SENT_HELLO,
                 WELCOMED,
                 IN_ITEMCHOICE,
                 IN_EQUIPMENTCHOICE,
@@ -36,31 +37,15 @@ namespace libclient {
                 GAME_OVER
             };
 
-            std::shared_ptr<Callback> callback;
-            std::shared_ptr<Model> model;
-            std::optional<websocket::network::WebSocketClient> webSocketClient;
-            NetworkState state = NetworkState::NOT_CONNECTED;
-            NetworkState stateBeforePause;
-
-            /**
-             * function to handle received messages
-             * @param message std::string received message from server
-             */
-            void onReceiveMessage(std::string message);
-
-            /**
-             * function to handle connection lost
-             */
-            void onClose();
-
-        public:
             Network(std::shared_ptr<libclient::Callback> c, std::shared_ptr<libclient::Model> m);
 
-            void connect(const std::string& servername, int port);
+            [[nodiscard]] NetworkState getState() const;
+
+            void connect(const std::string &servername, int port);
 
             void disconnect();
 
-            bool sendHello(std::string name, spy::network::RoleEnum role);
+            bool sendHello(const std::string &name, spy::network::RoleEnum role);
 
             bool sendItemChoice(std::variant<spy::util::UUID, spy::gadget::GadgetEnum> choice);
 
@@ -77,6 +62,24 @@ namespace libclient {
             bool sendRequestReplayMessage();
 
             bool sendReconnect();
+
+        private:
+            std::shared_ptr<Callback> callback;
+            std::shared_ptr<Model> model;
+            std::optional<websocket::network::WebSocketClient> webSocketClient;
+            NetworkState state = NetworkState::NOT_CONNECTED;
+            NetworkState stateBeforePause;
+
+            /**
+             * function to handle received messages
+             * @param message std::string received message from server
+             */
+            void onReceiveMessage(const std::string& message);
+
+            /**
+             * function to handle connection lost
+             */
+            void onClose();
     };
 }
 


### PR DESCRIPTION
Ich hab im LibClient Objekt zwei Setter hinzugefügt.
So kann der Client sich seinen Namen und seine Rolle speichern, ohne dafür ein extra Objekt im Cient erstellen zu müssen.